### PR TITLE
Update URLs for Reverse HTTP and HLS standards drafts

### DIFF
--- a/AirPlay.html
+++ b/AirPlay.html
@@ -467,7 +467,7 @@ txt:
       probably been introduced for the upcoming Apple television.</p>
 
       <p>The AirPlay server is a <em>HTTP</em> server (<a href="http://www.ietf.org/rfc/rfc2616.txt">RFC 2616</a>). Two connections are
-      made to this server, the second one being used as a <a href="http://www.ietf.org/id/draft-lentczner-rhttp-00.txt">reverse HTTP</a>
+      made to this server, the second one being used as a <a href="http://tools.ietf.org/id/draft-lentczner-rhttp-00.txt">reverse HTTP</a>
       connection. This allows a client to receive asynchronous events, such
       as playback status changes, from a server.</p>
 
@@ -1159,7 +1159,7 @@ Content-Length: 427
       </tr>
       </tbody>
       </table>
-      <p>MP4 movies are supported using progressive download. <a href="http://www.ietf.org/id/draft-pantos-http-live-streaming-07.txt">HTTP Live Streaming</a>
+      <p>MP4 movies are supported using progressive download. <a href="http://tools.ietf.org/id/draft-pantos-http-live-streaming-07.txt">HTTP Live Streaming</a>
       might be supported as well, as indicated by the <code>VideoHTTPLiveStreams</code>
       feature flag. The relative starting position, a float value between 0
       (beginning) and 1 (end) is used to start playing a video at the exact same
@@ -3318,8 +3318,8 @@ Content-Length: 0
       <ul>
       <li><a href="http://www.ietf.org/id/draft-cheshire-dnsext-multicastdns-15.txt">Multicast DNS</a></li>
       <li><a href="http://www.ietf.org/id/draft-cheshire-dnsext-dns-sd-11.txt">DNS-Based Service Discovery</a></li>
-      <li><a href="http://www.ietf.org/id/draft-lentczner-rhttp-00.txt">Reverse HTTP</a></li>
-      <li><a href="http://www.ietf.org/id/draft-pantos-http-live-streaming-07.txt">HTTP Live Streaming</a></li>
+      <li><a href="http://tools.ietf.org/id/draft-lentczner-rhttp-00.txt">Reverse HTTP</a></li>
+      <li><a href="http://tools.ietf.org/id/draft-pantos-http-live-streaming-07.txt">HTTP Live Streaming</a></li>
       </ul>
 
       <h2 id="resources-appleprotocols">9.3. Apple Protocols</h2>


### PR DESCRIPTION
Old URLs lead to 404s.
